### PR TITLE
disabled bytecode check for genericHandler SC

### DIFF
--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -120,10 +120,6 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 	if err != nil {
 		return nil, err
 	}
-	err = conn.EnsureHasBytecode(cfg.genericHandlerContract)
-	if err != nil {
-		return nil, err
-	}
 
 	bridgeContract, err := bridge.NewBridge(cfg.bridgeContract, conn.Client())
 	if err != nil {


### PR DESCRIPTION
In order to be able to use zero address for ERC721 handler and Generic handler, we need to disable bytecode check.