### PR TITLE
health server should lister for all networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 ## [Unreleased]
 
+## 2.1.2
+- Fixed health-check endpoint initialization for networks
+
 ## 2.1.1
 - Updated `chainbridge-utils`
 - Added DDC custom events

--- a/cmd/chainbridge/main.go
+++ b/cmd/chainbridge/main.go
@@ -223,7 +223,9 @@ func run(ctx *cli.Context) error {
 
 		go func() {
 			http.Handle("/metrics", promhttp.Handler())
-			http.HandleFunc("/health", h.HealthStatus)
+			for _, c := range c.Registry {
+			    http.HandleFunc(fmt.Sprintf("/health/%s", c.Name()), h.HealthStatus)
+			}
 			err := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 			if errors.Is(err, http.ErrServerClosed) {
 				log.Info("Health status server is shutting down", err)


### PR DESCRIPTION
App listens only for `/health` but the handler is waiting `/health/{network_name}`