### PR TITLE
Update chainbridge-utils lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Cerebellum-Network/chainbridge-substrate-events v0.0.0-20221201135328-b293e9eceda0
-	github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20221201134821-d1bef8924868
+	github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20230117160221-62c02df0d2e1
 	github.com/Cerebellum-Network/go-substrate-rpc-client/v4 v4.0.10-cere.0.20221125132510-a26124f21c96
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/ethereum/go-ethereum v1.10.17

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Cerebellum-Network/chainbridge-substrate-events v0.0.0-20221201135328-b293e9eceda0 h1:kuKAKJSHU1KRnX8IPY7Tw37eH7C4D4j+u8UlUX0Vq94=
 github.com/Cerebellum-Network/chainbridge-substrate-events v0.0.0-20221201135328-b293e9eceda0/go.mod h1:fZ95egyWaXKGMyof3dRibM/y4MouAC+L+9DdD/km8cw=
-github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20221201134821-d1bef8924868 h1:0Vbb5JVBtE4G5SqksaJ/UcF4FT2QbTHcHmkl4py40X8=
-github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20221201134821-d1bef8924868/go.mod h1:tdRalIIfnSzu9UX0DkyzUcysg3U4DMXUBQrwTG2kU2c=
+github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20230117160221-62c02df0d2e1 h1:dTQjWzKJrn9DmGMf9wvl1w+Y5+ojS4vTFcoGHy+O7XY=
+github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20230117160221-62c02df0d2e1/go.mod h1:tdRalIIfnSzu9UX0DkyzUcysg3U4DMXUBQrwTG2kU2c=
 github.com/Cerebellum-Network/go-substrate-rpc-client/v4 v4.0.10-cere.0.20221125132510-a26124f21c96 h1:TW3Am+cgEGChz+GVaXfUhsocNLeILIzPLkZh8f8i4/E=
 github.com/Cerebellum-Network/go-substrate-rpc-client/v4 v4.0.10-cere.0.20221125132510-a26124f21c96/go.mod h1:a598oNr73JhT5UQH1DJ9IEAkl1M3yshnAsm7U2F7gjI=
 github.com/ChainSafe/go-schnorrkel v1.0.0 h1:3aDA67lAykLaG1y3AOjs88dMxC88PgUuHRrLeDnvGIM=


### PR DESCRIPTION
Updated `chainbridge-utils` lib to implement health checks logging and debug BetterUptime 503 monitoring issue on DEV, STAGE.