### PR TITLE
Add draft workflow to disable relayers.

### DIFF
--- a/.github/workflows/disable-relayers.yml
+++ b/.github/workflows/disable-relayers.yml
@@ -1,0 +1,18 @@
+name: Disable Relayers
+
+on:
+  workflow_dispatch:
+
+jobs:
+  kubectl-setup-and-run:
+    runs-on: '["self-hosted", "cere-network-prd-deployer"]'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v1
+        with:
+          version: ${{ secrets.KUBECTL_VERSION }}
+      - name: Run kubectl get pods
+        run: |
+          kubectl get pods


### PR DESCRIPTION
Right now it cannot disable realyers. 
It just writes `kubectl get pods` 
I need this PR for test.