### PR TITLE
Update chainbridge-utils to fix blockstore issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.5
 
 require (
 	github.com/Cerebellum-Network/chainbridge-substrate-events v0.0.0-20240112154231-4f2db1e7a3d9
-	github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20240112163437-0f11d09acc2d
+	github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20240123112715-6db113397ae7
 	github.com/Cerebellum-Network/go-substrate-rpc-client/v7 v7.0.1-rc
 	github.com/ChainSafe/log15 v1.0.0
 	github.com/ethereum/go-ethereum v1.13.10
@@ -41,6 +41,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/gtank/merlin v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20231212171702-a0793ff0
 github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20231212171702-a0793ff00378/go.mod h1:D5o++aho1srs5AmENhtBhbD6JGKEqIVoGtKgSeipd8s=
 github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20240112163437-0f11d09acc2d h1:KnNrLMmqyVLMgNMgSp2cIBsJLUnC2vVyUgq9sEZUND0=
 github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20240112163437-0f11d09acc2d/go.mod h1:0eIvn9zbYgT08igtFhtkQJzAHhG8CwSq+BCmsq7NCU8=
+github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20240123112715-6db113397ae7 h1:ozLhYzcGPyM7BDDnJAT+34ZHc2VY6FWyV3rFxxNBEiM=
+github.com/Cerebellum-Network/chainbridge-utils v1.0.7-0.20240123112715-6db113397ae7/go.mod h1:hNZH7DOtyHQqz22U/B1ecP5qzElQVD1DVM7NNB6Q38s=
 github.com/Cerebellum-Network/go-substrate-rpc-client/v6 v6.0.2 h1:UzPU72po6gcitD0lBIfn3kk/a6WJyrEFZaF8zH+non4=
 github.com/Cerebellum-Network/go-substrate-rpc-client/v6 v6.0.2/go.mod h1:rOHTPlfCs+jqc9zPRTtH1XK8BsBeR2cdNBEoijjyi1Y=
 github.com/Cerebellum-Network/go-substrate-rpc-client/v7 v7.0.1-rc h1:HGg29xHzn64oYqlsPDGfi2eHJHYWp9hqzVjjW1k58/0=
@@ -333,6 +335,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
+github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=


### PR DESCRIPTION
Pulls [latest chaibridge-utils](https://github.com/Cerebellum-Network/chainbridge-utils/pull/15) that fix block store corruption issue