### PR TITLE
Update custom events to v4.8.5

### DIFF
--- a/shared/substrate/events.go
+++ b/shared/substrate/events.go
@@ -270,6 +270,7 @@ type EventRewarded struct {
 	ClusterId      types.H160
 	Era            types.U32
 	NodeProviderId types.AccountID
+	Amount         types.U128
 	Topics         []types.Hash
 }
 


### PR DESCRIPTION
Make the relayers compatible with the [blockchain node v4.8.5](https://github.com/Cerebellum-Network/blockchain-node/releases/tag/v4.8.5)